### PR TITLE
Add LOCAL_RPC_PORT and ACCOUNTS_PATH to the config

### DIFF
--- a/aws-deploy/bigtable/service-env.sh
+++ b/aws-deploy/bigtable/service-env.sh
@@ -1,17 +1,20 @@
+export RUST_LOG=WARN
 #RESTART=1 # Update the below block before uncommenting this line
 #if [[ -n "$RESTART" ]]; then
-#        WAIT_FOR_SUPERMAJORITY=53180900
-#        EXPECTED_BANK_HASH=Fi4p8z3AkfsuGXZzQ4TD28N8QDNSWC7ccqAqTs2GPdPu
+#        WAIT_FOR_SUPERMAJORITY=47390213
+#        EXPECTED_BANK_HASH=6LeTXckyBnYLhUDGGxaoT7rdEGvsrDeTCzCSJaK4grUE
 #fi
 EXPECTED_SHRED_VERSION=4175
 EXPECTED_GENESIS_HASH=Bk35uYWXgt6rN1rYzY7L7AqrrNwPhbg3MVde46YhMUCS
 TRUSTED_VALIDATOR_PUBKEYS=(7hoUyAJm3dG7XpFt4yB1f7AHZvaQygyHcb8hD66vP2Ai 9MyuD1XotiuYWtDHFJnXkPFKxdSL47uMJxYFjBDpFbQo)
 # export DOMI_METRICS_CONFIG=host=https://metrics.domichain.io:8086,db=mainnet-beta,u=mainnet-beta_write,p=password
+ACCOUNTS_PATH=~/bigtable-node/accounts7
 #Replace the below with a full path that includes both Domichain's binary and generic system binaries
 #Do not enter PATH=$PATH if you're planning to run the script as systemctl
 PATH=/home/domi/bin:$PATH
 #MINIMUM_MINUTES_BETWEEN_ARCHIVE=720
 RPC_URL=https://api.testnet.domichain.io
+LOCAL_RPC_PORT=8699
 ENTRYPOINT_HOST=103.106.59.69
 ENTRYPOINT_PORT=8001
 ENTRYPOINT=103.106.59.69:8001

--- a/aws-deploy/bigtable/warehouse.sh
+++ b/aws-deploy/bigtable/warehouse.sh
@@ -62,6 +62,11 @@ if [[ -z $RPC_URL ]]; then
   exit 1
 fi
 
+if [[ -z $LOCAL_RPC_PORT ]]; then
+  echo LOCAL_RPC_PORT environment variable not defined
+  exit 1
+fi
+
 # MINIMUM_MINUTES_BETWEEN_ARCHIVE=720 is useful to define in devnet's service-env.sh
 # since the devnet epochs are so short
 if [[ -z $MINIMUM_MINUTES_BETWEEN_ARCHIVE ]]; then
@@ -105,7 +110,7 @@ args=(
   --dynamic-port-range 9000-9020
   --entrypoint "$ENTRYPOINT"
   --expected-genesis-hash "$EXPECTED_GENESIS_HASH"
-  --rpc-port 8899
+  --rpc-port $LOCAL_RPC_PORT
   --private-rpc
   --identity "$identity_keypair"
   --ledger "$ledger_dir"
@@ -124,7 +129,7 @@ args=(
 #  --only-known-rpc
   --full-rpc-api
   --rpc-bind-address 0.0.0.0
-  --accounts ~/bigtable-node/accounts
+  --accounts "$ACCOUNTS_PATH"
 )
 
 if ! [[ $(domichain --version) =~ \ 1\.4\.[0-9]+ ]]; then
@@ -289,7 +294,7 @@ while true; do
     fi
 
     if ! $caught_up; then
-      if ! timeout 15m domichain catchup --url "$RPC_URL" "$identity_pubkey" http://127.0.0.1:8899; then
+      if ! timeout 15m domichain catchup --url "$RPC_URL" "$identity_pubkey" http://127.0.0.1:$LOCAL_RPC_PORT; then
         echo "catchup failed..."
         if [[ $SECONDS -gt 600 ]]; then
           datapoint_error validator-not-caught-up


### PR DESCRIPTION
#### Problem
We had to move RPC port for the warehouse node to a different one to prevent conflicts, it wasn't possible to configure it properly. Also it wasn't possible to setup a new accounts directory in case of a hard reset.

#### Summary of Changes
Added LOCAL_RPC_PORT to the config
Added ACCOUNTS_PATH to the config
